### PR TITLE
Salesforce integration command objects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 ruby '2.4.1'
 
 gem 'mail'
+gem 'restforce', '~> 2.5.3'
 
 group :test do
   gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,12 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     docile (1.1.5)
+    faraday (0.13.1)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
     hashdiff (0.3.4)
+    hashie (3.5.6)
     json (2.1.0)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
@@ -23,6 +28,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    multipart-post (2.0.0)
     parallel (1.11.2)
     parser (2.4.0.0)
       ast (~> 2.2)
@@ -35,6 +41,11 @@ GEM
     rainbow (2.2.2)
       rake
     rake (12.0.0)
+    restforce (2.5.3)
+      faraday (>= 0.9.0, <= 1.0)
+      faraday_middleware (>= 0.8.8, <= 1.0)
+      hashie (>= 1.2.0, < 4.0)
+      json (>= 1.7.5)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
       rspec-expectations (~> 3.6.0)
@@ -82,6 +93,7 @@ DEPENDENCIES
   mail
   pry
   rake
+  restforce (~> 2.5.3)
   rspec
   rubocop
   vcr

--- a/README.md
+++ b/README.md
@@ -3,15 +3,7 @@
 
 # Readme
 
-Explain your project here.
-
-
-## How to use this project
-
-* If your project is public and hosted in GitHub, you can use travis and coveralls for free.
-* If your project is private, you can host it for free in Gitlab and use their CI. You will need to pay for test coverage though.
-* Update badges with your user/repo names. Turn your repo ON in Travis.
-* Update license to your preferred one.
+This is the new donation system for the Survival International site.
 
 
 ### To initialise the project
@@ -28,6 +20,18 @@ You need to set your environment with a `STRIPE_API_KEY` variable equal to a val
 export STRIPE_API_KEY=blah
 ```
 
+You also need the following Salesforce environment variables:
+
+```bash
+export SALESFORCE_USERNAME='YOUR_USERNAME'
+export SALESFORCE_PASSWORD='YOUR_PASSWORD'
+export SALESFORCE_SECURITY_TOKEN='YOUR_SECURITY_TOKEN'
+export SALESFORCE_CLIENT_ID='YOUR_CLIENT_ID'
+export SALESFORCE_CLIENT_SECRET='YOUR_CLIENT_SECRET'
+export SALESFORCE_API_VERSION="38.0"
+```
+
+
 ### To run all tests and rubocop
 
 ```bash
@@ -39,26 +43,28 @@ bundle exec rake
 
 
 ```bash
-bundle exec rspec path/to/test/file.rb
+bundle exec rspec path/to/test/file.rb && rubocop
 ```
 
 
 ### To run one test
 
 ```bash
-bundle exec rspec path/to/test/file.rb:TESTLINENUMBER
+bundle exec rspec path/to/test/file.rb:TESTLINENUMBER && rubocop
 ```
+
 
 ## Testing emails in production
 
 You can send an email to any email address using the `test_email_server.rb` script, and setting your email server, username and password, like this:
 
 ```bash
-export EMAIL_SERVER=YOUR_EMAIL_SERVER
-export EMAIL_USERNAME=YOUR_USERNAME
-export EMAIL_PASSWORD=YOUR_PASSWORD
+export EMAIL_SERVER='YOUR_EMAIL_SERVER'
+export EMAIL_USERNAME='YOUR_USERNAME'
+export EMAIL_PASSWORD='YOUR_PASSWORD'
 bundle exec ruby scripts/test_email_server.rb 'YOUR_EMAIL_HERE'
 ```
+
 
 ## License
 

--- a/lib/payment.rb
+++ b/lib/payment.rb
@@ -2,19 +2,22 @@
 
 require 'net/http'
 require 'net/https'
+require 'salesforce/database'
 require 'thank_you_mailer'
 
 class Payment
   attr_accessor :request
 
-  def initialize(request)
+  def initialize(request, supporter_database = Salesforce::Database)
     @request = request
+    @supporter_database = supporter_database
   end
 
   def attempt
     response = post('https://api.stripe.com/v1/charges')
     if response.code == '200'
       ThankYouMailer.send_email(request.email, request.name)
+      supporter_database.add_donation(request)
       []
     elsif response.code == '402'
       [:card_error]
@@ -24,6 +27,8 @@ class Payment
   end
 
   private
+
+  attr_reader :supporter_database
 
   def post(url)
     uri = URI.parse(url)

--- a/lib/salesforce/client_api.rb
+++ b/lib/salesforce/client_api.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'restforce'
+require 'salesforce/client_error'
+require 'salesforce/result'
+
+module Salesforce
+  class ClientAPI
+    attr_reader :errors
+
+    def initialize(client = Restforce.new)
+      @client = client
+      @errors = []
+    end
+
+    def search(soql_expression)
+      client.query(soql_expression)
+    rescue Faraday::ClientError => error
+      save_client_error(error)
+      nil
+    end
+
+    def create(table, sobject_fields)
+      client.create!(table, sobject_fields)
+    rescue Faraday::ClientError => error
+      save_client_error(error)
+      nil
+    end
+
+    def fetch(table, id)
+      client.find(table, id)
+    end
+
+    private
+
+    attr_reader :client
+
+    def save_client_error(error)
+      @errors += ClientError.new(error).errors
+    end
+  end
+end

--- a/lib/salesforce/client_error.rb
+++ b/lib/salesforce/client_error.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Salesforce
+  ClientError = Struct.new(:client_error) do
+    def errors
+      error_collection.map { |error| symbolize(error['errorCode']) }
+    end
+
+    private
+
+    def error_collection
+      return [] unless client_error && client_error.response
+      client_error.response.fetch(:body, [])
+    end
+
+    def symbolize(error_code)
+      error_code.downcase.to_sym
+    end
+  end
+end

--- a/lib/salesforce/database.rb
+++ b/lib/salesforce/database.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'salesforce/donation_creator'
 require 'salesforce/supporter_creator'
 require 'salesforce/supporter_finder'
 
@@ -17,10 +18,6 @@ module Salesforce
       return [:missing_email] unless email_present?
       return supporter_result.errors unless supporter_result.okay?
       create_donation.errors
-    end
-
-    class DonationCreator
-      def self.execute(_data, _supporter); end
     end
 
     private

--- a/lib/salesforce/database.rb
+++ b/lib/salesforce/database.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Salesforce
+  class Database
+    def self.add_donation(_data); end
+  end
+end

--- a/lib/salesforce/database.rb
+++ b/lib/salesforce/database.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'salesforce/supporter_finder'
+
 module Salesforce
   class Database
     def self.add_donation(data)
@@ -14,10 +16,6 @@ module Salesforce
       return [:missing_email] unless email_present?
       return supporter_result.errors unless supporter_result.okay?
       create_donation.errors
-    end
-
-    class SupporterFinder
-      def self.execute(_field, _value); end
     end
 
     class SupporterCreator

--- a/lib/salesforce/database.rb
+++ b/lib/salesforce/database.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'salesforce/supporter_creator'
 require 'salesforce/supporter_finder'
 
 module Salesforce
@@ -16,10 +17,6 @@ module Salesforce
       return [:missing_email] unless email_present?
       return supporter_result.errors unless supporter_result.okay?
       create_donation.errors
-    end
-
-    class SupporterCreator
-      def self.execute(_data); end
     end
 
     class DonationCreator

--- a/lib/salesforce/database.rb
+++ b/lib/salesforce/database.rb
@@ -2,6 +2,67 @@
 
 module Salesforce
   class Database
-    def self.add_donation(_data); end
+    def self.add_donation(data)
+      new(data).add_donation
+    end
+
+    def initialize(data)
+      @data = data
+    end
+
+    def add_donation
+      return [:missing_email] unless email_present?
+      return supporter_result.errors unless supporter_result.okay?
+      create_donation.errors
+    end
+
+    class SupporterFinder
+      def self.execute(_field, _value); end
+    end
+
+    class SupporterCreator
+      def self.execute(_data); end
+    end
+
+    class DonationCreator
+      def self.execute(_data, _supporter); end
+    end
+
+    private
+
+    attr_reader :data
+
+    def email_present?
+      data.respond_to?(:email) && data.email
+    end
+
+    def supporter_result
+      @supporter_result ||= ensure_supporter_result
+    end
+
+    def ensure_supporter_result
+      return supporter_search_result if search_errors_or_supporter_exists?
+      create_supporter
+    end
+
+    def search_errors_or_supporter_exists?
+      supporter_search_result.errors? || supporter_search_result.item
+    end
+
+    def supporter
+      supporter_result.item
+    end
+
+    def supporter_search_result
+      @supporter_search_result ||= SupporterFinder.execute(:Email, data.email)
+    end
+
+    def create_supporter
+      SupporterCreator.execute(data)
+    end
+
+    def create_donation
+      DonationCreator.execute(data, supporter)
+    end
   end
 end

--- a/lib/salesforce/donation_creator.rb
+++ b/lib/salesforce/donation_creator.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'restforce'
+require 'salesforce/client_error'
+require 'salesforce/donation_validator'
+require 'salesforce/result'
+
+module Salesforce
+  class DonationCreator
+    def self.execute(data, supporter, client = Restforce.new)
+      new(client, data, supporter).execute
+    end
+
+    def initialize(client, data, supporter)
+      @client = client
+      @data = data
+      @supporter = supporter
+      @client_errors = []
+    end
+
+    def execute
+      Result.new(donation, errors)
+    end
+
+    private
+
+    attr_reader :client, :data, :supporter
+
+    def table
+      'Opportunity'
+    end
+
+    def donation
+      fetch(donation_id) if donation_id
+    end
+
+    def donation_id
+      @donation_id ||= create(validation.item) if validation.okay?
+    end
+
+    def validation
+      @validation ||= DonationValidator.execute(data, supporter)
+    end
+
+    def create(sobject_fields)
+      client.create!(table, sobject_fields)
+    rescue Faraday::ClientError => error
+      @client_errors += ClientError.new(error).errors
+      nil
+    end
+
+    def errors
+      validation.errors + @client_errors
+    end
+
+    def fetch(id)
+      client.find(table, id)
+    end
+  end
+end

--- a/lib/salesforce/donation_validator.rb
+++ b/lib/salesforce/donation_validator.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'salesforce/result'
+
+module Salesforce
+  class DonationValidator
+    def self.execute(data, supporter)
+      new(data, supporter).execute
+    end
+
+    def initialize(data, supporter)
+      @data = data
+      @supporter = supporter
+    end
+
+    def execute
+      Result.new(fields, errors)
+    end
+
+    private
+
+    attr_reader :data, :supporter
+
+    def fields
+      return unless errors.empty?
+      {
+        Amount: data.amount.to_s,
+        CloseDate: '2017-09-11',
+        Name: 'Online donation',
+        StageName: 'Received',
+        AccountId: supporter[:AccountId]
+      }
+    end
+
+    def errors
+      validation_errors = []
+      validation_errors << validate_data
+      validation_errors << validate_amount
+      validation_errors << validate_account_id
+      validation_errors.compact
+    end
+
+    def validate_data
+      :missing_data unless data
+    end
+
+    def validate_amount
+      :invalid_amount unless data && data.amount && !data.amount.to_i.zero?
+    end
+
+    def validate_account_id
+      :invalid_account_id unless supporter && supporter[:AccountId]
+    end
+  end
+end

--- a/lib/salesforce/result.rb
+++ b/lib/salesforce/result.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Salesforce
+  Result = Struct.new(:item, :errors) do
+    def okay?
+      errors.empty?
+    end
+
+    def errors?
+      !okay?
+    end
+  end
+end

--- a/lib/salesforce/supporter_creator.rb
+++ b/lib/salesforce/supporter_creator.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'restforce'
+require 'salesforce/client_error'
+require 'salesforce/result'
+require 'salesforce/supporter_validator'
+
+module Salesforce
+  class SupporterCreator
+    def self.execute(data, client = Restforce.new)
+      new(client, data).execute
+    end
+
+    def initialize(client, data)
+      @client = client
+      @data = data
+      @client_errors = []
+    end
+
+    def execute
+      Result.new(supporter, errors)
+    end
+
+    private
+
+    attr_reader :client, :data
+
+    def table
+      'Contact'
+    end
+
+    def supporter
+      fetch(supporter_id) if supporter_id
+    end
+
+    def supporter_id
+      @supporter_id ||= create(validation.item) if validation.okay?
+    end
+
+    def validation
+      @validation ||= SupporterValidator.execute(data)
+    end
+
+    def create(sobject_fields)
+      client.create!(table, sobject_fields)
+    rescue Faraday::ClientError => error
+      @client_errors += ClientError.new(error).errors
+      nil
+    end
+
+    def errors
+      validation.errors + @client_errors
+    end
+
+    def fetch(id)
+      client.find(table, id)
+    end
+  end
+end

--- a/lib/salesforce/supporter_finder.rb
+++ b/lib/salesforce/supporter_finder.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
-require 'restforce'
-require 'salesforce/client_error'
-require 'salesforce/result'
+require 'salesforce/client_api'
 
 module Salesforce
   class SupporterFinder
     ID = :Id
     SORT_FIELD = :First_entered__c
 
-    def self.execute(field, value, client = Restforce.new)
+    def self.execute(field, value, client = ClientAPI.new)
       new(client, field, value).execute
     end
 
@@ -17,7 +15,6 @@ module Salesforce
       @client = client
       @field = field
       @value = value
-      @client_errors = []
     end
 
     def execute
@@ -38,27 +35,23 @@ module Salesforce
     end
 
     def first_entered
-      search_results = search(expression)
-      search_results.sort_by { |item| item[SORT_FIELD] }.first if search_results
-    end
-
-    def search(soql_expression)
-      client.query(soql_expression)
-    rescue Faraday::ClientError => error
-      @client_errors += ClientError.new(error).errors
-      nil
+      search.sort_by { |item| item[SORT_FIELD] }.first if search
     end
 
     def expression
       "select #{ID}, #{SORT_FIELD} from #{table} where #{field}='#{value}'"
     end
 
-    def errors
-      @client_errors
+    def search
+      @search ||= client.search(expression)
     end
 
     def fetch(id)
-      client.find(table, id)
+      client.fetch(table, id)
+    end
+
+    def errors
+      client.errors
     end
   end
 end

--- a/lib/salesforce/supporter_finder.rb
+++ b/lib/salesforce/supporter_finder.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'restforce'
+require 'salesforce/client_error'
+require 'salesforce/result'
+
+module Salesforce
+  class SupporterFinder
+    ID = :Id
+    SORT_FIELD = :First_entered__c
+
+    def self.execute(field, value, client = Restforce.new)
+      new(client, field, value).execute
+    end
+
+    def initialize(client, field, value)
+      @client = client
+      @field = field
+      @value = value
+      @client_errors = []
+    end
+
+    def execute
+      Result.new(supporter, errors)
+    end
+
+    private
+
+    attr_reader :client, :field, :value
+
+    def table
+      'Contact'
+    end
+
+    def supporter
+      first = first_entered
+      fetch(first[ID]) if first
+    end
+
+    def first_entered
+      search_results = search(expression)
+      search_results.sort_by { |item| item[SORT_FIELD] }.first if search_results
+    end
+
+    def search(soql_expression)
+      client.query(soql_expression)
+    rescue Faraday::ClientError => error
+      @client_errors += ClientError.new(error).errors
+      nil
+    end
+
+    def expression
+      "select #{ID}, #{SORT_FIELD} from #{table} where #{field}='#{value}'"
+    end
+
+    def errors
+      @client_errors
+    end
+
+    def fetch(id)
+      client.find(table, id)
+    end
+  end
+end

--- a/lib/salesforce/supporter_validator.rb
+++ b/lib/salesforce/supporter_validator.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'salesforce/result'
+
+module Salesforce
+  class SupporterValidator
+    def self.execute(data)
+      new(data).execute
+    end
+
+    def initialize(data)
+      @data = data
+    end
+
+    def execute
+      Result.new(fields, errors)
+    end
+
+    private
+
+    attr_reader :data
+
+    def fields
+      return unless errors.empty?
+      {
+        LastName: data.name,
+        Email: data.email
+      }
+    end
+
+    def errors
+      validation_errors = []
+      validation_errors << :missing_data unless data
+      validation_errors << :invalid_last_name unless data && data.name
+      validation_errors << :invalid_email unless data && data.email
+      validation_errors.compact
+    end
+  end
+end

--- a/spec/salesforce/client_error_spec.rb
+++ b/spec/salesforce/client_error_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'salesforce/client_error'
+
+module Salesforce
+  RSpec.describe ClientError do
+    FaradayErrorFake = Struct.new(:response)
+
+    it 'deals with Faraday client errors' do
+      response = { body: [{ 'errorCode' => 'SOME_ERROR' }] }
+      faraday_error = FaradayErrorFake.new(response)
+      errors = ClientError.new(faraday_error).errors
+      expect(errors).to eq([:some_error])
+    end
+
+    it 'returns nothing if there are no Faraday client errors' do
+      response = { body: [] }
+      faraday_error = FaradayErrorFake.new(response)
+      errors = ClientError.new(faraday_error).errors
+      expect(errors).to be_empty
+    end
+
+    it 'returns nothing if there is no response body' do
+      response = {}
+      faraday_error = FaradayErrorFake.new(response)
+      errors = ClientError.new(faraday_error).errors
+      expect(errors).to be_empty
+    end
+
+    it 'returns nothing if there is no response' do
+      faraday_error = FaradayErrorFake.new(nil)
+      errors = ClientError.new(faraday_error).errors
+      expect(errors).to be_empty
+    end
+
+    it 'returns nothing if there is no Faraday client error' do
+      errors = ClientError.new(nil).errors
+      expect(errors).to be_empty
+    end
+  end
+end

--- a/spec/salesforce/data_structs_for_tests.rb
+++ b/spec/salesforce/data_structs_for_tests.rb
@@ -2,4 +2,6 @@
 
 module Salesforce
   RawSupporterData = Struct.new(:name, :email)
+  RawDonationData = Struct.new(:amount)
+  SupporterSObjectFake = Struct.new(:AccountId)
 end

--- a/spec/salesforce/data_structs_for_tests.rb
+++ b/spec/salesforce/data_structs_for_tests.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Salesforce
+  RawSupporterData = Struct.new(:name, :email)
+end

--- a/spec/salesforce/database_spec.rb
+++ b/spec/salesforce/database_spec.rb
@@ -16,8 +16,7 @@ module Salesforce
         donation_result = Result.new({ Id: '5678' }, [])
 
         allow(SupporterFinder).to receive(:execute).and_return(finder_result)
-        allow(described_class::DonationCreator).to receive(:execute)
-          .and_return(donation_result)
+        allow(DonationCreator).to receive(:execute).and_return(donation_result)
         expect(described_class.add_donation(data)).to be_empty
       end
 
@@ -28,8 +27,7 @@ module Salesforce
 
         allow(SupporterFinder).to receive(:execute).and_return(finder_result)
         allow(SupporterCreator).to receive(:execute).and_return(creation_result)
-        allow(described_class::DonationCreator).to receive(:execute)
-          .and_return(donation_result)
+        allow(DonationCreator).to receive(:execute).and_return(donation_result)
         expect(described_class.add_donation(data)).to be_empty
       end
     end
@@ -65,8 +63,7 @@ module Salesforce
         donation_result = Result.new(nil, [:donation_error])
 
         allow(SupporterFinder).to receive(:execute).and_return(finder_result)
-        allow(described_class::DonationCreator).to receive(:execute)
-          .and_return(donation_result)
+        allow(DonationCreator).to receive(:execute).and_return(donation_result)
         expect(described_class.add_donation(data)).to eq([:donation_error])
       end
     end

--- a/spec/salesforce/database_spec.rb
+++ b/spec/salesforce/database_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'salesforce/database'
+require 'salesforce/result'
+require 'spec_helper'
+
+RawData = Struct.new(:email)
+
+module Salesforce
+  RSpec.describe Database do
+    let(:data) { RawData.new('email@test.com') }
+
+    describe 'when sucessful' do
+      it 'creates a donation if supporter exists' do
+        finder_result = Result.new({ Id: '1234' }, [])
+        donation_result = Result.new({ Id: '5678' }, [])
+
+        allow(described_class::SupporterFinder).to receive(:execute)
+          .and_return(finder_result)
+        allow(described_class::DonationCreator).to receive(:execute)
+          .and_return(donation_result)
+        expect(described_class.add_donation(data)).to be_empty
+      end
+
+      it 'creates supporter and donation if supporter does not exist' do
+        finder_result = Result.new(nil, [])
+        creation_result = Result.new({ Id: '1234' }, [])
+        donation_result = Result.new({ Id: '5678' }, [])
+
+        allow(described_class::SupporterFinder).to receive(:execute)
+          .and_return(finder_result)
+        allow(described_class::SupporterCreator).to receive(:execute)
+          .and_return(creation_result)
+        allow(described_class::DonationCreator).to receive(:execute)
+          .and_return(donation_result)
+        expect(described_class.add_donation(data)).to be_empty
+      end
+    end
+
+    describe 'when unsuccessful' do
+      it 'returns errors if email is not present' do
+        expect(described_class.add_donation('foo')).to eq([:missing_email])
+      end
+
+      it 'returns errors if email is null' do
+        expect(described_class.add_donation(RawData.new(nil)))
+          .to eq([:missing_email])
+      end
+
+      it 'returns errors if problems with finder' do
+        finder_result = Result.new(nil, [:finder_error])
+
+        allow(described_class::SupporterFinder).to receive(:execute)
+          .and_return(finder_result)
+        expect(described_class.add_donation(data)).to eq([:finder_error])
+      end
+
+      it 'returns errors if problems with supporter creation' do
+        finder_result = Result.new(nil, [])
+        creation_result = Result.new(nil, [:creation_error])
+
+        allow(described_class::SupporterFinder).to receive(:execute)
+          .and_return(finder_result)
+        allow(described_class::SupporterCreator).to receive(:execute)
+          .and_return(creation_result)
+        expect(described_class.add_donation(data)).to eq([:creation_error])
+      end
+
+      it 'returns errors if problems with donation creation' do
+        finder_result = Result.new({ Id: '1234' }, [])
+        donation_result = Result.new(nil, [:donation_error])
+
+        allow(described_class::SupporterFinder).to receive(:execute)
+          .and_return(finder_result)
+        allow(described_class::DonationCreator).to receive(:execute)
+          .and_return(donation_result)
+        expect(described_class.add_donation(data)).to eq([:donation_error])
+      end
+    end
+  end
+end

--- a/spec/salesforce/database_spec.rb
+++ b/spec/salesforce/database_spec.rb
@@ -15,8 +15,7 @@ module Salesforce
         finder_result = Result.new({ Id: '1234' }, [])
         donation_result = Result.new({ Id: '5678' }, [])
 
-        allow(described_class::SupporterFinder).to receive(:execute)
-          .and_return(finder_result)
+        allow(SupporterFinder).to receive(:execute).and_return(finder_result)
         allow(described_class::DonationCreator).to receive(:execute)
           .and_return(donation_result)
         expect(described_class.add_donation(data)).to be_empty
@@ -27,8 +26,7 @@ module Salesforce
         creation_result = Result.new({ Id: '1234' }, [])
         donation_result = Result.new({ Id: '5678' }, [])
 
-        allow(described_class::SupporterFinder).to receive(:execute)
-          .and_return(finder_result)
+        allow(SupporterFinder).to receive(:execute).and_return(finder_result)
         allow(described_class::SupporterCreator).to receive(:execute)
           .and_return(creation_result)
         allow(described_class::DonationCreator).to receive(:execute)
@@ -50,8 +48,7 @@ module Salesforce
       it 'returns errors if problems with finder' do
         finder_result = Result.new(nil, [:finder_error])
 
-        allow(described_class::SupporterFinder).to receive(:execute)
-          .and_return(finder_result)
+        allow(SupporterFinder).to receive(:execute).and_return(finder_result)
         expect(described_class.add_donation(data)).to eq([:finder_error])
       end
 
@@ -59,8 +56,7 @@ module Salesforce
         finder_result = Result.new(nil, [])
         creation_result = Result.new(nil, [:creation_error])
 
-        allow(described_class::SupporterFinder).to receive(:execute)
-          .and_return(finder_result)
+        allow(SupporterFinder).to receive(:execute).and_return(finder_result)
         allow(described_class::SupporterCreator).to receive(:execute)
           .and_return(creation_result)
         expect(described_class.add_donation(data)).to eq([:creation_error])
@@ -70,8 +66,7 @@ module Salesforce
         finder_result = Result.new({ Id: '1234' }, [])
         donation_result = Result.new(nil, [:donation_error])
 
-        allow(described_class::SupporterFinder).to receive(:execute)
-          .and_return(finder_result)
+        allow(SupporterFinder).to receive(:execute).and_return(finder_result)
         allow(described_class::DonationCreator).to receive(:execute)
           .and_return(donation_result)
         expect(described_class.add_donation(data)).to eq([:donation_error])

--- a/spec/salesforce/database_spec.rb
+++ b/spec/salesforce/database_spec.rb
@@ -27,8 +27,7 @@ module Salesforce
         donation_result = Result.new({ Id: '5678' }, [])
 
         allow(SupporterFinder).to receive(:execute).and_return(finder_result)
-        allow(described_class::SupporterCreator).to receive(:execute)
-          .and_return(creation_result)
+        allow(SupporterCreator).to receive(:execute).and_return(creation_result)
         allow(described_class::DonationCreator).to receive(:execute)
           .and_return(donation_result)
         expect(described_class.add_donation(data)).to be_empty
@@ -57,8 +56,7 @@ module Salesforce
         creation_result = Result.new(nil, [:creation_error])
 
         allow(SupporterFinder).to receive(:execute).and_return(finder_result)
-        allow(described_class::SupporterCreator).to receive(:execute)
-          .and_return(creation_result)
+        allow(SupporterCreator).to receive(:execute).and_return(creation_result)
         expect(described_class.add_donation(data)).to eq([:creation_error])
       end
 

--- a/spec/salesforce/donation_creator_spec.rb
+++ b/spec/salesforce/donation_creator_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'salesforce/data_structs_for_tests'
+require 'salesforce/donation_creator'
+require 'spec_helper'
+
+module Salesforce
+  RSpec.describe DonationCreator do
+    let(:data) { RawDonationData.new('2000') }
+    let(:supporter) { SupporterSObjectFake.new('0013D00000LBYutQAH') }
+
+    describe 'when successful', vcr: { record: :once } do
+      it 'creates a donation' do
+        result = create_donation(data, supporter)
+        expect(result).to be_okay
+        expect(result.item).not_to be_nil
+      end
+    end
+
+    describe 'when unsuccessful', vcr: { record: :once } do
+      it 'fails if data is invalid' do
+        result = create_donation(nil, supporter)
+        expect(result).not_to be_okay
+        expect(result.item).to be_nil
+      end
+
+      it 'fails if supporter is invalid' do
+        result = create_donation(data, nil)
+        expect(result).not_to be_okay
+        expect(result.item).to be_nil
+      end
+
+      it 'fails if there is a creation problem' do
+        result = create_donation(data, SupporterSObjectFake.new('1234'))
+        expect(result).not_to be_okay
+        expect(result.item).to be_nil
+      end
+    end
+
+    def create_donation(data, supporter)
+      client = Restforce.new(host: 'cs70.salesforce.com')
+      described_class.execute(data, supporter, client)
+    end
+  end
+end

--- a/spec/salesforce/donation_creator_spec.rb
+++ b/spec/salesforce/donation_creator_spec.rb
@@ -38,7 +38,7 @@ module Salesforce
     end
 
     def create_donation(data, supporter)
-      client = Restforce.new(host: 'cs70.salesforce.com')
+      client = ClientAPI.new(Restforce.new(host: 'cs70.salesforce.com'))
       described_class.execute(data, supporter, client)
     end
   end

--- a/spec/salesforce/donation_validator_spec.rb
+++ b/spec/salesforce/donation_validator_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'salesforce/data_structs_for_tests'
+require 'salesforce/donation_validator'
+require 'spec_helper'
+
+module Salesforce
+  RSpec.describe DonationValidator do
+    let(:result) { validate_values(amount: '2000', account_id: '1') }
+    let(:fields) { result.item }
+
+    describe 'Salesforce required fields' do
+      it 'requires an amount' do
+        expect(fields[:Amount]).to eq('2000')
+      end
+
+      it 'requires a closed date' do
+        expect(fields[:CloseDate]).to eq('2017-09-11')
+      end
+
+      it 'requires a name' do
+        expect(fields[:Name]).to eq('Online donation')
+      end
+
+      it 'requires a stage name' do
+        expect(fields[:StageName]).to eq('Received')
+      end
+    end
+
+    describe 'application required fields' do
+      it 'requires an account id' do
+        expect(fields[:AccountId]).to eq('1')
+      end
+    end
+
+    describe 'validations' do
+      it 'has no validation errors if data is valid' do
+        expect(result).to be_okay
+        expect(fields).not_to be_nil
+      end
+
+      it 'handles missing data' do
+        result = validate(nil, SupporterSObjectFake.new('1'))
+        expect(result.item).to be_nil
+        expect(result.errors).to include(:missing_data)
+      end
+
+      it 'handles missing amount' do
+        result = validate_values(amount: nil, account_id: '1')
+        expect(result.item).to be_nil
+        expect(result.errors).to include(:invalid_amount)
+      end
+
+      it 'handles invalid amount' do
+        result = validate_values(amount: 'asdf', account_id: '1')
+        expect(result.item).to be_nil
+        expect(result.errors).to include(:invalid_amount)
+      end
+
+      it 'handles missing supporter' do
+        result = validate(RawDonationData.new('1'), nil)
+        expect(result.item).to be_nil
+        expect(result.errors).to include(:invalid_account_id)
+      end
+
+      it 'handles invalid account id' do
+        result = validate_values(amount: '2000', account_id: nil)
+        expect(result.item).to be_nil
+        expect(result.errors).to include(:invalid_account_id)
+      end
+    end
+
+    def validate(data, supporter)
+      described_class.execute(data, supporter)
+    end
+
+    def validate_values(values)
+      data = RawDonationData.new(values[:amount])
+      supporter = SupporterSObjectFake.new(values[:account_id])
+      described_class.execute(data, supporter)
+    end
+  end
+end

--- a/spec/salesforce/supporter_creator_spec.rb
+++ b/spec/salesforce/supporter_creator_spec.rb
@@ -30,17 +30,22 @@ module Salesforce
       end
 
       it 'fails if there is a creation problem' do
-        allow(SupporterValidator).to receive(:execute)
-          .and_return(Result.new(nil, []))
-        result = create_supporter(data)
+        result = create_supporter(data, ClientFake.new(nil, [:creation_error]))
         expect(result).not_to be_okay
         expect(result.item).to be_nil
       end
     end
 
-    def create_supporter(data)
-      client = Restforce.new(host: 'cs70.salesforce.com')
+    def create_supporter(data, client_fake = nil)
+      client_default = ClientAPI.new(Restforce.new(host: 'cs70.salesforce.com'))
+      client = client_fake || client_default
       described_class.execute(data, client)
+    end
+
+    ClientFake = Struct.new(:supporter_id, :errors) do
+      def create(_table, _fields)
+        supporter_id
+      end
     end
   end
 end

--- a/spec/salesforce/supporter_creator_spec.rb
+++ b/spec/salesforce/supporter_creator_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'salesforce/data_structs_for_tests'
+require 'salesforce/supporter_creator'
+require 'spec_helper'
+
+module Salesforce
+  RSpec.describe SupporterCreator do
+    let(:data) { RawSupporterData.new('A Name', 'test@test.com') }
+
+    describe 'when successful', vcr: { record: :once } do
+      it 'creates a supporter' do
+        result = create_supporter(data)
+        expect(result).to be_okay
+        expect(result.item[:Email]).to eq('test@test.com')
+      end
+    end
+
+    describe 'when unsuccessful', vcr: { record: :once } do
+      it 'fails if there is no data' do
+        result = create_supporter(nil)
+        expect(result).not_to be_okay
+        expect(result.item).to be_nil
+      end
+
+      it 'fails if data is invalid' do
+        result = create_supporter(RawSupporterData.new(nil, nil))
+        expect(result).not_to be_okay
+        expect(result.item).to be_nil
+      end
+
+      it 'fails if there is a creation problem' do
+        allow(SupporterValidator).to receive(:execute)
+          .and_return(Result.new(nil, []))
+        result = create_supporter(data)
+        expect(result).not_to be_okay
+        expect(result.item).to be_nil
+      end
+    end
+
+    def create_supporter(data)
+      client = Restforce.new(host: 'cs70.salesforce.com')
+      described_class.execute(data, client)
+    end
+  end
+end

--- a/spec/salesforce/supporter_finder_spec.rb
+++ b/spec/salesforce/supporter_finder_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'salesforce/supporter_finder'
+
+module Salesforce
+  RSpec.describe SupporterFinder do
+    describe 'when successful', vcr: { record: :once } do
+      it 'returns the supporter if exists' do
+        result = search_by(:Email, 'test@test.com')
+        expect(result).to be_okay
+        expect(result.item[:Email]).to eq('test@test.com')
+      end
+
+      it 'picks oldest supporter if several with same email' do
+        result = search_by(:Email, 'repeated_email@test.com')
+        expect(result).to be_okay
+        expect(result.item[described_class::SORT_FIELD]).to eq('2017-08-01')
+      end
+
+      it 'returns nothing if no supporter' do
+        result = search_by(:Email, 'i-dont-exist@test.com')
+        expect(result).to be_okay
+        expect(result.item).to be_nil
+      end
+    end
+
+    describe 'when unsuccessful', vcr: { record: :once } do
+      it 'fails if search field does not exist' do
+        result = search_by(:foo, 'bar')
+        expect(result.item).to be_nil
+        expect(result.errors).to eq([:invalid_field])
+      end
+    end
+
+    def search_by(field, value)
+      client = Restforce.new(host: 'cs70.salesforce.com')
+      described_class.execute(field, value, client)
+    end
+  end
+end

--- a/spec/salesforce/supporter_finder_spec.rb
+++ b/spec/salesforce/supporter_finder_spec.rb
@@ -34,7 +34,7 @@ module Salesforce
     end
 
     def search_by(field, value)
-      client = Restforce.new(host: 'cs70.salesforce.com')
+      client = ClientAPI.new(Restforce.new(host: 'cs70.salesforce.com'))
       described_class.execute(field, value, client)
     end
   end

--- a/spec/salesforce/supporter_validator_spec.rb
+++ b/spec/salesforce/supporter_validator_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'salesforce/data_structs_for_tests'
+require 'salesforce/supporter_validator'
+require 'spec_helper'
+
+module Salesforce
+  RSpec.describe SupporterValidator do
+    let(:data) { RawSupporterData.new('A Name', 'test@test.com') }
+    let(:result) { validate(data) }
+    let(:fields) { result.item }
+
+    describe 'Salesforce required fields' do
+      it 'requires a last name' do
+        expect(fields[:LastName]).to eq('A Name')
+      end
+    end
+
+    describe 'application required fields' do
+      it 'requires an email' do
+        expect(fields[:Email]).to eq('test@test.com')
+      end
+    end
+
+    describe 'validations' do
+      it 'has no validation errors if data is valid' do
+        expect(result).to be_okay
+        expect(fields).not_to be_nil
+      end
+
+      it 'handles null data' do
+        result = validate(nil)
+        expect(result.item).to be_nil
+        expect(result.errors).to include(:missing_data)
+      end
+
+      it 'handles missing last name' do
+        result = validate(RawSupporterData.new(nil, 'test@test.com'))
+        expect(result.item).to be_nil
+        expect(result.errors).to include(:invalid_last_name)
+      end
+
+      it 'handles missing email' do
+        result = validate(RawSupporterData.new('A Name', nil))
+        expect(result.item).to be_nil
+        expect(result.errors).to include(:invalid_email)
+      end
+    end
+
+    def validate(data)
+      described_class.execute(data)
+    end
+  end
+end


### PR DESCRIPTION
This PR is a first stab at creating the logic to:
- Find a supporter by email in Salesforce
- if it doesn't exist, create one
- use the `AccountId` field of the supporter to create a donation attached to that supporter

An approach using command objects was used.

At this stage we didn't include ALL the fields that are included in the old code when creating a supporter or a donation. We are only including the ones that are marked as required in Salesforce and the ones that are required for the application. Please refer to the commit messages for more detail.

(**Beware:** check the commits locally, as GitHub changes the order of the commits in Pull Requests!)

`cs70.salesforce.com` is the sandbox we are running the tests against. During the development of this branch, we learned some gotchas of working with the Salesforce API with our current upstream configuration, which we have documented at Freshdesk:

<https://survivalinternational.freshdesk.com/solution/articles/33000203530-sandbox>
