### PR TITLE
Stripe extraction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '2.4.1'
 
 gem 'mail'
 gem 'restforce', '~> 2.5.3'
+gem 'stripe'
 
 group :test do
   gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.1)
     slop (3.6.0)
+    stripe (3.7.0)
+      faraday (~> 0.10)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
     thor (0.19.4)
@@ -96,6 +98,7 @@ DEPENDENCIES
   restforce (~> 2.5.3)
   rspec
   rubocop
+  stripe
   vcr
   webmock
 

--- a/lib/payment.rb
+++ b/lib/payment.rb
@@ -1,58 +1,26 @@
 # frozen_string_literal: true
 
-require 'net/http'
-require 'net/https'
 require 'salesforce/database'
+require 'stripe/gateway'
 require 'thank_you_mailer'
 
 class Payment
-  attr_accessor :request
-
-  def initialize(request, supporter_database = Salesforce::Database)
-    @request = request
+  def initialize(request_data, supporter_database = Salesforce::Database)
+    @request_data = request_data
     @supporter_database = supporter_database
   end
 
   def attempt
-    response = post('https://api.stripe.com/v1/charges')
-    errors = stripe_error_codes.fetch(response.code, [:invalid_request])
-    if errors.empty?
-      ThankYouMailer.send_email(request.email, request.name)
-      supporter_database.add_donation(request)
+    result = Stripe::Gateway.charge(request_data)
+    if result.okay?
+      ThankYouMailer.send_email(request_data.email, request_data.name)
+      supporter_database.add_donation(request_data)
+    else
+      result.errors
     end
-    errors
   end
 
   private
 
-  attr_reader :supporter_database
-
-  def post(url)
-    uri = URI.parse(url)
-    https = Net::HTTP.new(uri.host, uri.port)
-    https.use_ssl = true
-    http_request = Net::HTTP::Post.new(uri.path)
-    http_request.basic_auth(ENV['STRIPE_API_KEY'], '')
-    http_request.set_form_data(form_data)
-    https.request(http_request)
-  end
-
-  def form_data
-    {
-      'amount' => request.amount,
-      'currency' => request.currency,
-      'source[object]' => 'card',
-      'source[number]' => request.card_number,
-      'source[exp_month]' => request.exp_month,
-      'source[exp_year]' => request.exp_year,
-      'source[cvc]' => request.cvc
-    }
-  end
-
-  def stripe_error_codes
-    {
-      '200' => [],
-      '402' => [:card_error]
-    }
-  end
+  attr_reader :request_data, :supporter_database
 end

--- a/lib/stripe/gateway.rb
+++ b/lib/stripe/gateway.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'stripe'
+require 'stripe/result'
+
+module Stripe
+  class Gateway
+    def self.charge(data)
+      new(data).charge
+    end
+
+    def initialize(data)
+      @data = data
+      @errors = []
+    end
+
+    def charge
+      return Result.new(nil, [:missing_data]) unless data
+      Result.new(charge_result, errors)
+    end
+
+    private
+
+    attr_reader :data, :errors
+
+    def charge_result
+      charge_and_rescue_data_related_errors
+    rescue Stripe::RateLimitError
+      save_error(:too_many_requests)
+    rescue Stripe::APIConnectionError
+      save_error(:connection_problems)
+    rescue Stripe::StripeError
+      save_error(:stripe_error)
+    rescue StandardError
+      save_error(:unknown_error)
+    end
+
+    def charge_and_rescue_data_related_errors
+      create_stripe_charge
+    rescue Stripe::AuthenticationError
+      save_error(:invalid_api_key)
+    rescue Stripe::InvalidRequestError
+      save_error(:invalid_parameter)
+    rescue Stripe::CardError
+      save_error(:declined_card)
+    rescue Stripe::APIError
+      save_error(:invalid_response_object)
+    end
+
+    def create_stripe_charge
+      Stripe.api_key = ENV['STRIPE_API_KEY']
+      Stripe::Charge.create(input_data)
+    end
+
+    def input_data
+      {
+        amount: data.amount,
+        currency: data.currency,
+        source: data.token,
+        description: "Charge for #{data.email}"
+      }
+    end
+
+    def save_error(error_code)
+      @errors << error_code
+      nil
+    end
+  end
+end

--- a/lib/stripe/input_data_validator.rb
+++ b/lib/stripe/input_data_validator.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'stripe/result'
+
+module Stripe
+  class InputDataValidator
+    def self.execute(data)
+      new(data).execute
+    end
+
+    def initialize(data)
+      @data = data
+    end
+
+    def execute
+      Result.new(fields, errors)
+    end
+
+    private
+
+    attr_reader :data
+
+    def fields
+      return unless errors.empty?
+      {
+        amount: data.amount,
+        currency: data.currency,
+        source: data.token,
+        description: "Charge for #{data.email}"
+      }
+    end
+
+    def errors
+      validation_errors = []
+      validation_errors << validate_data
+      validation_errors << validate_amount
+      validation_errors << validate_currency
+      validation_errors << validate_token
+      validation_errors << validate_email
+      validation_errors.compact
+    end
+
+    def validate_data
+      :missing_data unless data
+    end
+
+    def validate_amount
+      :missing_amount unless data&.amount
+    end
+
+    def validate_currency
+      :missing_currency unless data&.currency
+    end
+
+    def validate_token
+      :missing_token unless data&.token
+    end
+
+    def validate_email
+      :missing_email unless data&.email
+    end
+  end
+end

--- a/lib/stripe/result.rb
+++ b/lib/stripe/result.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Stripe
+  Result = Struct.new(:item, :errors) do
+    def okay?
+      errors.empty?
+    end
+
+    def errors?
+      !okay?
+    end
+  end
+end

--- a/spec/payment_spec.rb
+++ b/spec/payment_spec.rb
@@ -2,77 +2,53 @@
 
 require 'payment'
 require 'salesforce/database'
+require 'stripe/gateway'
 require 'spec_helper'
-require 'support/with_env'
 require 'thank_you_mailer'
 
 RSpec.describe Payment do
-  include Support::WithEnv
+  Request = Struct.new(:email, :name)
 
-  Request = Struct.new(
-    :amount, :currency, :card_number, :cvc, :exp_year, :exp_month, :email, :name
-  )
-
-  let(:request) { Request.new(nil) }
+  let(:request) { Request.new('user@example.com', 'Name') }
   let(:payment) { described_class.new(request) }
 
-  before { allow(Salesforce::Database).to receive(:add_donation) }
-
-  it 'stores the request object passed in the initializer' do
-    expect(payment.request).to eq(request)
+  describe 'when the gateway is unsuccessful' do
+    it 'returns the gateway error' do
+      gateway_result = Stripe::Result.new(nil, [:error])
+      allow(Stripe::Gateway).to receive(:charge).and_return(gateway_result)
+      expect(described_class.new(request).attempt).to eq([:error])
+    end
   end
 
-  describe '#attempt', vcr: { record: :once } do
-    it 'fails without an api key' do
-      with_env('STRIPE_API_KEY' => '') do
-        expect(payment.attempt).to eq([:invalid_request])
-      end
+  describe 'when the gateway is successful' do
+    let(:gateway_result) { Stripe::Result.new('irrelevant', []) }
+
+    before do
+      allow(Stripe::Gateway).to receive(:charge).and_return(gateway_result)
+      allow(Salesforce::Database).to receive(:add_donation).and_return([])
     end
 
-    it 'fails with an invalid api key' do
-      with_env('STRIPE_API_KEY' => 'aaaaa') do
-        expect(payment.attempt).to eq([:invalid_request])
-      end
+    it 'returns errors if there is a problem with the supporter database' do
+      errors = %i[foo bar]
+      allow(Salesforce::Database).to receive(:add_donation).and_return(errors)
+      expect(described_class.new(request).attempt).to eq(errors)
     end
 
-    it 'fails with a valid api key but no other parameters' do
-      expect(payment.attempt).to eq([:invalid_request])
+    it 'succeeds if there are no problems with the supporter database' do
+      expect(described_class.new(request).attempt).to be_empty
     end
 
-    it 'fails with a valid api key and invalid card number' do
-      request = Request.new(
-        '1000', 'usd', '1235424242424242', '123', '2020', '01',
-        'irrelevant', 'irrelevant'
-      )
-      payment = described_class.new(request)
-      expect(payment.attempt).to eq([:card_error])
+    it 'sends a thank you email' do
+      allow(ThankYouMailer).to receive(:send_email)
+      described_class.new(request).attempt
+      expect(ThankYouMailer).to have_received(:send_email)
+        .with('user@example.com', 'Name')
     end
 
-    context 'success' do
-      let(:request) do
-        Request.new(
-          '1000', 'usd', '4242424242424242', '123', '2020', '01',
-          'user@example.com', 'Name'
-        )
-      end
-
-      it 'succeeds with a valid api key and valid parameters' do
-        payment = described_class.new(request)
-        expect(payment.attempt).to be_empty
-      end
-
-      it 'should send a thank you email' do
-        allow(ThankYouMailer).to receive(:send_email)
-        described_class.new(request).attempt
-        expect(ThankYouMailer).to have_received(:send_email)
-          .with('user@example.com', 'Name')
-      end
-
-      it 'adds the donation to the supporters database' do
-        described_class.new(request).attempt
-        expect(Salesforce::Database).to have_received(:add_donation)
-          .with(request)
-      end
+    it 'adds the donation to the supporters database' do
+      described_class.new(request).attempt
+      expect(Salesforce::Database).to have_received(:add_donation)
+        .with(request)
     end
   end
 end

--- a/spec/stripe/gateway_spec.rb
+++ b/spec/stripe/gateway_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'stripe/gateway'
+require 'support/with_env'
+
+module Stripe
+  RSpec.describe Gateway do
+    RawStripeData = Struct.new(:amount, :currency, :token, :email, :name)
+
+    describe 'when unsuccessful', vcr: { record: :once } do
+      include Support::WithEnv
+
+      let(:stripe_endpoint) { 'https://api.stripe.com/v1/charges' }
+      let(:data) { RawStripeData.new(nil, nil, 'tok_visa', nil, nil) }
+
+      it 'fails without an API key' do
+        with_env('STRIPE_API_KEY' => '') do
+          expect_charge_to_fail_with(:invalid_api_key)
+        end
+      end
+
+      it 'fails with an invalid API key' do
+        with_env('STRIPE_API_KEY' => 'aaaaa') do
+          expect_charge_to_fail_with(:invalid_api_key)
+        end
+      end
+
+      it 'fails with a valid API key but missing parameters' do
+        expect_charge_to_fail_with(:invalid_parameter)
+      end
+
+      it 'fails with a valid API key and invalid card number' do
+        data = RawStripeData.new(
+          '1000', 'usd', 'tok_chargeDeclined', 'user@test.com', 'foo'
+        )
+        expect_charge_to_fail_with(:declined_card, data)
+      end
+
+      it 'fails with a valid API key and expired card' do
+        data = RawStripeData.new(
+          '1000', 'usd', 'tok_chargeDeclinedExpiredCard', 'user@test.com', 'foo'
+        )
+        expect_charge_to_fail_with(:declined_card, data)
+      end
+
+      it 'fails due to net conflicts' do
+        stub_request(:post, stripe_endpoint).to_return(status: 409, body: '')
+        expect_charge_to_fail_with(:invalid_response_object)
+      end
+
+      it 'fails due to too many requests' do
+        allow(Stripe::Charge)
+          .to receive(:create)
+          .and_raise(Stripe::RateLimitError)
+        expect_charge_to_fail_with(:too_many_requests)
+      end
+
+      it 'fails due to a Stripe connection error' do
+        allow(Stripe::Charge)
+          .to receive(:create)
+          .and_raise(Stripe::APIConnectionError)
+        expect_charge_to_fail_with(:connection_problems)
+      end
+
+      it 'fails due to Stripe server errors' do
+        allow(Stripe::Charge).to receive(:create).and_raise(Stripe::StripeError)
+        expect_charge_to_fail_with(:stripe_error)
+      end
+
+      it 'fails due to reasons unrelated to Stripe' do
+        allow(Stripe::Charge).to receive(:create).and_raise(StandardError)
+        expect_charge_to_fail_with(:unknown_error)
+      end
+
+      it 'fails if no data is provided' do
+        result = described_class.charge(nil)
+        expect(result.item).to be_nil
+        expect(result.errors).to eq([:missing_data])
+      end
+    end
+
+    describe 'when successful', vcr: { record: :once } do
+      it 'succeeds with a valid API key and valid parameters' do
+        data = RawStripeData.new(
+          '1000', 'usd', 'tok_visa', 'user@example.com', 'Name'
+        )
+        result = described_class.charge(data)
+        expect(result.item.status).to eq('succeeded')
+        expect(result.errors).to be_empty
+      end
+    end
+
+    def expect_charge_to_fail_with(error_code, custom_data = nil)
+      result = described_class.charge(custom_data || data)
+      expect(result.item).to be_nil
+      expect(result.errors).to eq([error_code])
+    end
+  end
+end

--- a/spec/stripe/input_data_validator_spec.rb
+++ b/spec/stripe/input_data_validator_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'stripe/input_data_validator'
+require 'spec_helper'
+
+module Stripe
+  RSpec.describe InputDataValidator do
+    RawInputData = Struct.new(:amount, :currency, :token, :email, :name)
+
+    let(:data) do
+      RawInputData.new(
+        '1000', 'usd', 'stripe_token', 'user@example.com', 'Name'
+      )
+    end
+    let(:result) { validate(data) }
+    let(:fields) { result.item }
+
+    describe 'Stripe required fields' do
+      it 'has required field amount' do
+        expect(fields[:amount]).to eq('1000')
+      end
+
+      it 'has required field currency' do
+        expect(fields[:currency]).to eq('usd')
+      end
+
+      it 'has required field Stripe token' do
+        expect(fields[:source]).to eq('stripe_token')
+      end
+
+      it 'has optional field description with the donor email' do
+        expect(fields[:description]).to include('user@example.com')
+      end
+    end
+
+    describe 'validations' do
+      it 'has no validation errors if data is present' do
+        expect(result).to be_okay
+        expect(fields).not_to be_nil
+      end
+
+      it 'handles null data' do
+        result = validate(nil)
+        expect(result.item).to be_nil
+        expect(result.errors).to include(:missing_data)
+      end
+
+      it 'handles missing amount' do
+        data = RawInputData.new(
+          nil, 'usd', 'stripe_token', 'user@example.com', 'Name'
+        )
+        result = validate(data)
+        expect(result.item).to be_nil
+        expect(result.errors).to include(:missing_amount)
+      end
+
+      it 'handles missing currency' do
+        data = RawInputData.new(
+          '1000', nil, 'stripe_token', 'user@example.com', 'Name'
+        )
+        result = validate(data)
+        expect(result.item).to be_nil
+        expect(result.errors).to include(:missing_currency)
+      end
+
+      it 'handles missing token' do
+        data = RawInputData.new(
+          '1000', 'usd', nil, 'user@example.com', 'Name'
+        )
+        result = validate(data)
+        expect(result.item).to be_nil
+        expect(result.errors).to include(:missing_token)
+      end
+
+      it 'handles missing email' do
+        data = RawInputData.new(
+          '1000', 'usd', 'stripe_token', nil, 'Name'
+        )
+        result = validate(data)
+        expect(result.item).to be_nil
+        expect(result.errors).to include(:missing_email)
+      end
+    end
+
+    def validate(data)
+      described_class.execute(data)
+    end
+  end
+end

--- a/spec/support/with_env.rb
+++ b/spec/support/with_env.rb
@@ -2,13 +2,6 @@
 
 module Support
   module WithEnv
-    # Allows setting temporary ENV variables for a test
-    #
-    # Usage:
-    #
-    # with_env("POLLING_INTERVAL" => 1, "EMAIL" => "always") do
-    #   .. test here...
-    # end
     def with_env(settings)
       old_settings = {}
       settings.each do |variable, value|
@@ -17,7 +10,7 @@ module Support
       end
       yield
     ensure
-      settings.each do |variable, _value|
+      settings.each_key do |variable|
         ENV[variable] = old_settings[variable]
       end
     end


### PR DESCRIPTION
This is a very simple first stab at introducing Stripe in the backend, receiving a token from the front end.
Initially we thought we could be able to avoid using JavaScript and do all the payment handling from the server. However that would make PCI compliance more strict, so we changed our minds.

In addition, Radar, which is Stripe's integrated solution for automatic fraud protection, only supports integrations that make use of client-side tokenization.

Test values and tokens taken from the API docs:

<https://stripe.com/docs/testing>

and

<https://stripe.com/docs/api/ruby#error_handling>

The description field is optional but was added as a fast an easy way to include donor email. It was
a requirement from one of our offices to display the email of the donor so that they can more easily scan the payments in Stripe.

Regarding the validation, for now it justs validates presence of fields (i.e., they are not null).