### PR TITLE
Update Stripe key name to STRIPE_SECRET_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ bundle install
 
 ## Tests
 
-You need to set your environment with a `STRIPE_API_KEY` variable equal to a valid Stripe API private test key before running the tests. For example:
+You need to set your environment with a `STRIPE_SECRET_KEY` variable equal to a valid Stripe API private test key before running the tests. For example:
 
 ```bash
-export STRIPE_API_KEY=blah
+export STRIPE_SECRET_KEY=blah
 ```
 
 You also need the following Salesforce environment variables:

--- a/lib/stripe/gateway.rb
+++ b/lib/stripe/gateway.rb
@@ -48,7 +48,7 @@ module Stripe
     end
 
     def create_stripe_charge
-      Stripe.api_key = ENV['STRIPE_API_KEY']
+      Stripe.api_key = ENV['STRIPE_SECRET_KEY']
       Stripe::Charge.create(input_data)
     end
 

--- a/spec/stripe/gateway_spec.rb
+++ b/spec/stripe/gateway_spec.rb
@@ -26,13 +26,13 @@ module Stripe
       end
 
       it 'fails without an API key' do
-        with_env('STRIPE_API_KEY' => '') do
+        with_env('STRIPE_SECRET_KEY' => '') do
           expect_charge_to_fail_with(:invalid_api_key)
         end
       end
 
       it 'fails with an invalid API key' do
-        with_env('STRIPE_API_KEY' => 'aaaaa') do
+        with_env('STRIPE_SECRET_KEY' => 'aaaaa') do
           expect_charge_to_fail_with(:invalid_api_key)
         end
       end


### PR DESCRIPTION
Now that we are going to use Stripe in the frontend,
we have two Stripe keys, the public (for the frontend)
and the secret (for the backend). So we need to
differenciate them.

The credentials repo was updated and I also added
the two new keys to both Heroku and Travis.