### PR TITLE
Unify test datastructs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ and append `bundle exec` in front of any CLI command that requires this gem.
 
 # Development
 
-To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version. Then push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
 
 ## To initialise the project
 
@@ -73,6 +71,29 @@ bundle exec rspec path/to/test/file.rb && rubocop
 
 ```bash
 bundle exec rspec path/to/test/file.rb:TESTLINENUMBER && rubocop
+```
+
+
+### To release a new version
+
+
+To release a new version, update the version number in `version.rb`, and describe your changes in the changelog. Then run:
+
+```bash
+git tag -a VERSION_HERE -m "DESCRIPTION_HERE"
+```
+
+which will create a git tag for the version. Then push git commits and tags:
+
+```bash
+git push origin master --tags
+```
+
+and push the `.gem` file to [rubygems.org](https://rubygems.org):
+
+```bash
+gem build donation_system.gemspec
+gem push donation_system-VERSION_HERE.gem
 ```
 
 

--- a/lib/donation_system/donation_data.rb
+++ b/lib/donation_system/donation_data.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module DonationSystem
+  DonationData = Struct.new(:request_data, :payment_data)
+end

--- a/lib/donation_system/salesforce/database.rb
+++ b/lib/donation_system/salesforce/database.rb
@@ -26,7 +26,10 @@ module DonationSystem
       attr_reader :data
 
       def email_present?
-        data.respond_to?(:email) && data.email
+        data &&
+          data.respond_to?(:request_data) &&
+          data.request_data.respond_to?(:email) &&
+          data.request_data.email
       end
 
       def supporter_result
@@ -47,7 +50,8 @@ module DonationSystem
       end
 
       def supporter_search_result
-        @supporter_search_result ||= SupporterFinder.execute(:Email, data.email)
+        email = data.request_data.email
+        @supporter_search_result ||= SupporterFinder.execute(:Email, email)
       end
 
       def create_supporter

--- a/lib/donation_system/salesforce/donation_validator.rb
+++ b/lib/donation_system/salesforce/donation_validator.rb
@@ -25,7 +25,7 @@ module DonationSystem
       def fields
         return unless errors.empty?
         {
-          Amount: data.amount.to_s,
+          Amount: data.payment_data.amount.to_s,
           CloseDate: '2017-09-11',
           Name: 'Online donation',
           StageName: 'Received',
@@ -46,11 +46,17 @@ module DonationSystem
       end
 
       def validate_amount
-        :invalid_amount unless data&.amount && !data.amount.to_i.zero?
+        :invalid_amount unless data&.payment_data&.amount && integer_amount?
       end
 
       def validate_account_id
         :invalid_account_id unless supporter && supporter[:AccountId]
+      end
+
+      def integer_amount?
+        Integer(data.payment_data.amount)
+      rescue ArgumentError
+        false
       end
     end
   end

--- a/lib/donation_system/salesforce/supporter_validator.rb
+++ b/lib/donation_system/salesforce/supporter_validator.rb
@@ -24,16 +24,16 @@ module DonationSystem
       def fields
         return unless errors.empty?
         {
-          LastName: data.name,
-          Email: data.email
+          LastName: data.request_data.name,
+          Email: data.request_data.email
         }
       end
 
       def errors
         validation_errors = []
         validation_errors << :missing_data unless data
-        validation_errors << :invalid_last_name unless data&.name
-        validation_errors << :invalid_email unless data&.email
+        validation_errors << :invalid_last_name unless data&.request_data&.name
+        validation_errors << :invalid_email unless data&.request_data&.email
         validation_errors.compact
       end
     end

--- a/spec/donation_system/data_structs_for_tests.rb
+++ b/spec/donation_system/data_structs_for_tests.rb
@@ -5,7 +5,6 @@ module DonationSystem
                               :name, :email,
                               :address, :city, :state, :zip, :country)
   RawPaymentData = Struct.new(:status)
-  RawSupporterData = Struct.new(:name, :email)
   RawDonationData = Struct.new(:amount)
   SupporterFake = Struct.new(:AccountId)
 

--- a/spec/donation_system/data_structs_for_tests.rb
+++ b/spec/donation_system/data_structs_for_tests.rb
@@ -3,5 +3,5 @@
 module DonationSystem
   RawSupporterData = Struct.new(:name, :email)
   RawDonationData = Struct.new(:amount)
-  SupporterSObjectFake = Struct.new(:AccountId)
+  SupporterFake = Struct.new(:AccountId)
 end

--- a/spec/donation_system/data_structs_for_tests.rb
+++ b/spec/donation_system/data_structs_for_tests.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 module DonationSystem
+  RawRequestData = Struct.new(:amount, :currency, :giftaid, :token,
+                              :name, :email,
+                              :address, :city, :state, :zip, :country)
   RawSupporterData = Struct.new(:name, :email)
   RawDonationData = Struct.new(:amount)
   SupporterFake = Struct.new(:AccountId)
+
+  VALID_REQUEST_DATA = RawRequestData.new(
+    '12.345', 'gbp', true, 'tok_visa', 'Firstname Lastname', 'user@example.com',
+    'Address', 'City', 'State', 'Z1PC0D3', 'Country'
+  ).freeze
 end

--- a/spec/donation_system/data_structs_for_tests.rb
+++ b/spec/donation_system/data_structs_for_tests.rb
@@ -4,6 +4,7 @@ module DonationSystem
   RawRequestData = Struct.new(:amount, :currency, :giftaid, :token,
                               :name, :email,
                               :address, :city, :state, :zip, :country)
+  RawPaymentData = Struct.new(:status)
   RawSupporterData = Struct.new(:name, :email)
   RawDonationData = Struct.new(:amount)
   SupporterFake = Struct.new(:AccountId)
@@ -12,4 +13,6 @@ module DonationSystem
     '12.345', 'gbp', true, 'tok_visa', 'Firstname Lastname', 'user@example.com',
     'Address', 'City', 'State', 'Z1PC0D3', 'Country'
   ).freeze
+
+  VALID_PAYMENT_DATA = RawPaymentData.new('succeeded').freeze
 end

--- a/spec/donation_system/data_structs_for_tests.rb
+++ b/spec/donation_system/data_structs_for_tests.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module DonationSystem
+  RawSupporterData = Struct.new(:name, :email)
+  RawDonationData = Struct.new(:amount)
+  SupporterSObjectFake = Struct.new(:AccountId)
+end

--- a/spec/donation_system/data_structs_for_tests.rb
+++ b/spec/donation_system/data_structs_for_tests.rb
@@ -4,8 +4,7 @@ module DonationSystem
   RawRequestData = Struct.new(:amount, :currency, :giftaid, :token,
                               :name, :email,
                               :address, :city, :state, :zip, :country)
-  RawPaymentData = Struct.new(:status)
-  RawDonationData = Struct.new(:amount)
+  RawPaymentData = Struct.new(:status, :amount)
   SupporterFake = Struct.new(:AccountId)
 
   VALID_REQUEST_DATA = RawRequestData.new(
@@ -13,5 +12,5 @@ module DonationSystem
     'Address', 'City', 'State', 'Z1PC0D3', 'Country'
   ).freeze
 
-  VALID_PAYMENT_DATA = RawPaymentData.new('succeeded').freeze
+  VALID_PAYMENT_DATA = RawPaymentData.new('succeeded', 2000).freeze
 end

--- a/spec/donation_system/payment_spec.rb
+++ b/spec/donation_system/payment_spec.rb
@@ -1,54 +1,50 @@
 # frozen_string_literal: true
 
+require 'donation_system/data_structs_for_tests'
 require 'donation_system/payment'
-require 'donation_system/salesforce/database'
-require 'donation_system/stripe_wrapper/gateway'
-require 'donation_system/thank_you_mailer'
 require 'spec_helper'
 
 module DonationSystem
   RSpec.describe Payment do
-    Request = Struct.new(:email, :name)
-
-    let(:request) { Request.new('user@example.com', 'Name') }
+    let(:request_data) { VALID_REQUEST_DATA }
 
     describe 'when the gateway is unsuccessful' do
       it 'returns the gateway error' do
         result = StripeWrapper::Result.new(nil, [:error])
         allow(StripeWrapper::Gateway).to receive(:charge).and_return(result)
-        expect(described_class.attempt(request)).to eq([:error])
+        expect(described_class.attempt(request_data)).to eq([:error])
       end
     end
 
     describe 'when the gateway is successful' do
-      let(:result) { StripeWrapper::Result.new('irrelevant', []) }
+      let(:result) { StripeWrapper::Result.new('stripe_result', []) }
 
       before do
         allow(StripeWrapper::Gateway).to receive(:charge).and_return(result)
+        allow(ThankYouMailer).to receive(:send_email)
         allow(Salesforce::Database).to receive(:add_donation).and_return([])
       end
 
       it 'returns errors if there is a problem with the supporter database' do
         errors = %i[foo bar]
         allow(Salesforce::Database).to receive(:add_donation).and_return(errors)
-        expect(described_class.attempt(request)).to eq(errors)
+        expect(described_class.attempt(request_data)).to eq(errors)
       end
 
       it 'succeeds if there are no problems with the supporter database' do
-        expect(described_class.attempt(request)).to be_empty
+        expect(described_class.attempt(request_data)).to be_empty
       end
 
       it 'sends a thank you email' do
-        allow(ThankYouMailer).to receive(:send_email)
-        described_class.attempt(request)
+        described_class.attempt(request_data)
         expect(ThankYouMailer).to have_received(:send_email)
-          .with('user@example.com', 'Name')
+          .with('user@example.com', 'Firstname Lastname')
       end
 
       it 'adds the donation to the supporters database' do
-        described_class.attempt(request)
+        described_class.attempt(request_data)
         expect(Salesforce::Database).to have_received(:add_donation)
-          .with(request)
+          .with(DonationData.new(request_data, result.item))
       end
     end
   end

--- a/spec/donation_system/salesforce/data_structs_for_tests.rb
+++ b/spec/donation_system/salesforce/data_structs_for_tests.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module DonationSystem
-  module Salesforce
-    RawSupporterData = Struct.new(:name, :email)
-    RawDonationData = Struct.new(:amount)
-    SupporterSObjectFake = Struct.new(:AccountId)
-  end
-end

--- a/spec/donation_system/salesforce/database_spec.rb
+++ b/spec/donation_system/salesforce/database_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
+require 'donation_system/data_structs_for_tests'
+require 'donation_system/donation_data'
 require 'donation_system/salesforce/database'
 require 'donation_system/salesforce/result'
 require 'spec_helper'
 
 module DonationSystem
   module Salesforce
-    RawData = Struct.new(:email)
-
     RSpec.describe Database do
-      let(:data) { RawData.new('email@test.com') }
+      let(:data) { DonationData.new(VALID_REQUEST_DATA, VALID_PAYMENT_DATA) }
 
       describe 'when sucessful' do
         it 'creates a donation if supporter exists' do
@@ -35,12 +35,19 @@ module DonationSystem
 
       describe 'when unsuccessful' do
         it 'returns errors if email is not present' do
+          expect(described_class.add_donation(nil)).to eq([:missing_email])
+
           expect(described_class.add_donation('foo')).to eq([:missing_email])
+
+          data = DonationData.new(nil, VALID_PAYMENT_DATA)
+          expect(described_class.add_donation(data)).to eq([:missing_email])
         end
 
         it 'returns errors if email is null' do
-          expect(described_class.add_donation(RawData.new(nil)))
-            .to eq([:missing_email])
+          request_data = VALID_REQUEST_DATA.dup
+          request_data.email = nil
+          data = DonationData.new(request_data, VALID_PAYMENT_DATA)
+          expect(described_class.add_donation(data)).to eq([:missing_email])
         end
 
         it 'returns errors if problems with finder' do

--- a/spec/donation_system/salesforce/donation_creator_spec.rb
+++ b/spec/donation_system/salesforce/donation_creator_spec.rb
@@ -8,7 +8,7 @@ module DonationSystem
   module Salesforce
     RSpec.describe DonationCreator do
       let(:data) { RawDonationData.new('2000') }
-      let(:supporter) { SupporterSObjectFake.new('0013D00000LBYutQAH') }
+      let(:supporter) { SupporterFake.new('0013D00000LBYutQAH') }
 
       describe 'when successful', vcr: { record: :once } do
         it 'creates a donation' do
@@ -32,7 +32,7 @@ module DonationSystem
         end
 
         it 'fails if there is a creation problem' do
-          result = create_donation(data, SupporterSObjectFake.new('1234'))
+          result = create_donation(data, SupporterFake.new('1234'))
           expect(result).not_to be_okay
           expect(result.item).to be_nil
         end

--- a/spec/donation_system/salesforce/donation_creator_spec.rb
+++ b/spec/donation_system/salesforce/donation_creator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'donation_system/salesforce/data_structs_for_tests'
+require 'donation_system/data_structs_for_tests'
 require 'donation_system/salesforce/donation_creator'
 require 'spec_helper'
 

--- a/spec/donation_system/salesforce/donation_creator_spec.rb
+++ b/spec/donation_system/salesforce/donation_creator_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 require 'donation_system/data_structs_for_tests'
+require 'donation_system/donation_data'
 require 'donation_system/salesforce/donation_creator'
 require 'spec_helper'
 
 module DonationSystem
   module Salesforce
     RSpec.describe DonationCreator do
-      let(:data) { RawDonationData.new('2000') }
+      let(:data) { DonationData.new(VALID_REQUEST_DATA, VALID_PAYMENT_DATA) }
       let(:supporter) { SupporterFake.new('0013D00000LBYutQAH') }
 
       describe 'when successful', vcr: { record: :once } do

--- a/spec/donation_system/salesforce/donation_validator_spec.rb
+++ b/spec/donation_system/salesforce/donation_validator_spec.rb
@@ -41,7 +41,7 @@ module DonationSystem
         end
 
         it 'handles missing data' do
-          result = validate(nil, SupporterSObjectFake.new('1'))
+          result = validate(nil, SupporterFake.new('1'))
           expect(result.item).to be_nil
           expect(result.errors).to include(:missing_data)
         end
@@ -77,7 +77,7 @@ module DonationSystem
 
       def validate_values(values)
         data = RawDonationData.new(values[:amount])
-        supporter = SupporterSObjectFake.new(values[:account_id])
+        supporter = SupporterFake.new(values[:account_id])
         described_class.execute(data, supporter)
       end
     end

--- a/spec/donation_system/salesforce/donation_validator_spec.rb
+++ b/spec/donation_system/salesforce/donation_validator_spec.rb
@@ -1,83 +1,87 @@
 # frozen_string_literal: true
 
 require 'donation_system/data_structs_for_tests'
+require 'donation_system/donation_data'
 require 'donation_system/salesforce/donation_validator'
 require 'spec_helper'
 
 module DonationSystem
   module Salesforce
     RSpec.describe DonationValidator do
-      let(:result) { validate_values(amount: '2000', account_id: '1') }
+      let(:data) { DonationData.new(VALID_REQUEST_DATA, VALID_PAYMENT_DATA) }
+      let(:supporter) { SupporterFake.new('1') }
+      let(:result) { validate(data, supporter) }
       let(:fields) { result.item }
 
       describe 'Salesforce required fields' do
-        it 'requires an amount' do
+        it 'has required field amount' do
           expect(fields[:Amount]).to eq('2000')
         end
 
-        it 'requires a closed date' do
+        it 'has required field closed date' do
           expect(fields[:CloseDate]).to eq('2017-09-11')
         end
 
-        it 'requires a name' do
+        it 'has required field name' do
           expect(fields[:Name]).to eq('Online donation')
         end
 
-        it 'requires a stage name' do
+        it 'has required field stage name' do
           expect(fields[:StageName]).to eq('Received')
         end
       end
 
       describe 'application required fields' do
-        it 'requires an account id' do
+        it 'has required field account id' do
           expect(fields[:AccountId]).to eq('1')
         end
       end
 
       describe 'validations' do
+        let(:request_data) { VALID_REQUEST_DATA.dup }
+        let(:payment_data) { VALID_PAYMENT_DATA.dup }
+
         it 'has no validation errors if data is valid' do
           expect(result).to be_okay
           expect(fields).not_to be_nil
         end
 
         it 'handles missing data' do
-          result = validate(nil, SupporterFake.new('1'))
+          result = validate(nil, supporter)
           expect(result.item).to be_nil
           expect(result.errors).to include(:missing_data)
         end
 
         it 'handles missing amount' do
-          result = validate_values(amount: nil, account_id: '1')
+          payment_data.amount = nil
+          data = DonationData.new(request_data, payment_data)
+          result = validate(data, supporter)
           expect(result.item).to be_nil
           expect(result.errors).to include(:invalid_amount)
         end
 
         it 'handles invalid amount' do
-          result = validate_values(amount: 'asdf', account_id: '1')
+          payment_data.amount = 'adsf'
+          data = DonationData.new(request_data, payment_data)
+          result = validate(data, supporter)
           expect(result.item).to be_nil
           expect(result.errors).to include(:invalid_amount)
         end
 
         it 'handles missing supporter' do
-          result = validate(RawDonationData.new('1'), nil)
+          result = validate(data, nil)
           expect(result.item).to be_nil
           expect(result.errors).to include(:invalid_account_id)
         end
 
         it 'handles invalid account id' do
-          result = validate_values(amount: '2000', account_id: nil)
+          result = validate(data, SupporterFake.new(nil))
           expect(result.item).to be_nil
           expect(result.errors).to include(:invalid_account_id)
         end
       end
 
       def validate(data, supporter)
-        described_class.execute(data, supporter)
-      end
-
-      def validate_values(values)
-        data = RawDonationData.new(values[:amount])
-        supporter = SupporterFake.new(values[:account_id])
         described_class.execute(data, supporter)
       end
     end

--- a/spec/donation_system/salesforce/donation_validator_spec.rb
+++ b/spec/donation_system/salesforce/donation_validator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'donation_system/salesforce/data_structs_for_tests'
+require 'donation_system/data_structs_for_tests'
 require 'donation_system/salesforce/donation_validator'
 require 'spec_helper'
 

--- a/spec/donation_system/salesforce/supporter_creator_spec.rb
+++ b/spec/donation_system/salesforce/supporter_creator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'donation_system/salesforce/data_structs_for_tests'
+require 'donation_system/data_structs_for_tests'
 require 'donation_system/salesforce/supporter_creator'
 require 'spec_helper'
 

--- a/spec/donation_system/salesforce/supporter_creator_spec.rb
+++ b/spec/donation_system/salesforce/supporter_creator_spec.rb
@@ -1,19 +1,20 @@
 # frozen_string_literal: true
 
 require 'donation_system/data_structs_for_tests'
+require 'donation_system/donation_data'
 require 'donation_system/salesforce/supporter_creator'
 require 'spec_helper'
 
 module DonationSystem
   module Salesforce
     RSpec.describe SupporterCreator do
-      let(:data) { RawSupporterData.new('A Name', 'test@test.com') }
+      let(:data) { DonationData.new(VALID_REQUEST_DATA, VALID_PAYMENT_DATA) }
 
       describe 'when successful', vcr: { record: :once } do
         it 'creates a supporter' do
           result = create_supporter(data)
           expect(result).to be_okay
-          expect(result.item[:Email]).to eq('test@test.com')
+          expect(result.item[:Email]).to eq('user@example.com')
         end
       end
 
@@ -25,7 +26,7 @@ module DonationSystem
         end
 
         it 'fails if data is invalid' do
-          result = create_supporter(RawSupporterData.new(nil, nil))
+          result = create_supporter(nil)
           expect(result).not_to be_okay
           expect(result.item).to be_nil
         end

--- a/spec/donation_system/salesforce/supporter_validator_spec.rb
+++ b/spec/donation_system/salesforce/supporter_validator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'donation_system/salesforce/data_structs_for_tests'
+require 'donation_system/data_structs_for_tests'
 require 'donation_system/salesforce/supporter_validator'
 require 'spec_helper'
 

--- a/spec/donation_system/salesforce/supporter_validator_spec.rb
+++ b/spec/donation_system/salesforce/supporter_validator_spec.rb
@@ -1,29 +1,32 @@
 # frozen_string_literal: true
 
 require 'donation_system/data_structs_for_tests'
+require 'donation_system/donation_data'
 require 'donation_system/salesforce/supporter_validator'
 require 'spec_helper'
 
 module DonationSystem
   module Salesforce
     RSpec.describe SupporterValidator do
-      let(:data) { RawSupporterData.new('A Name', 'test@test.com') }
+      let(:data) { DonationData.new(VALID_REQUEST_DATA, VALID_PAYMENT_DATA) }
       let(:result) { validate(data) }
       let(:fields) { result.item }
 
       describe 'Salesforce required fields' do
         it 'requires a last name' do
-          expect(fields[:LastName]).to eq('A Name')
+          expect(fields[:LastName]).to eq('Firstname Lastname')
         end
       end
 
       describe 'application required fields' do
         it 'requires an email' do
-          expect(fields[:Email]).to eq('test@test.com')
+          expect(fields[:Email]).to eq('user@example.com')
         end
       end
 
       describe 'validations' do
+        let(:request_data) { VALID_REQUEST_DATA.dup }
+
         it 'has no validation errors if data is valid' do
           expect(result).to be_okay
           expect(fields).not_to be_nil
@@ -36,13 +39,15 @@ module DonationSystem
         end
 
         it 'handles missing last name' do
-          result = validate(RawSupporterData.new(nil, 'test@test.com'))
+          request_data.name = nil
+          result = validate(DonationData.new(request_data, VALID_PAYMENT_DATA))
           expect(result.item).to be_nil
           expect(result.errors).to include(:invalid_last_name)
         end
 
         it 'handles missing email' do
-          result = validate(RawSupporterData.new('A Name', nil))
+          request_data.email = nil
+          result = validate(DonationData.new(request_data, VALID_PAYMENT_DATA))
           expect(result.item).to be_nil
           expect(result.errors).to include(:invalid_email)
         end

--- a/spec/donation_system/stripe_wrapper/input_data_validator_spec.rb
+++ b/spec/donation_system/stripe_wrapper/input_data_validator_spec.rb
@@ -1,32 +1,26 @@
 # frozen_string_literal: true
 
+require 'donation_system/data_structs_for_tests'
 require 'donation_system/stripe_wrapper/input_data_validator'
 require 'spec_helper'
 
 module DonationSystem
   module StripeWrapper
     RSpec.describe InputDataValidator do
-      RawInputData = Struct.new(:amount, :currency, :token, :email, :name)
-
-      let(:data) do
-        RawInputData.new(
-          '10.50', 'usd', 'stripe_token', 'user@example.com', 'Name'
-        )
-      end
-      let(:result) { validate(data) }
-      let(:fields) { result.item }
-
       describe 'Stripe required fields' do
+        let(:result) { validate(VALID_REQUEST_DATA) }
+        let(:fields) { result.item }
+
         it 'has required field amount' do
-          expect(fields[:amount]).to eq(1050)
+          expect(fields[:amount]).to eq(1234)
         end
 
         it 'has required field currency' do
-          expect(fields[:currency]).to eq('usd')
+          expect(fields[:currency]).to eq('gbp')
         end
 
         it 'has required field Stripe token' do
-          expect(fields[:source]).to eq('stripe_token')
+          expect(fields[:source]).to eq('tok_visa')
         end
 
         it 'has optional field description with the donor email' do
@@ -35,9 +29,12 @@ module DonationSystem
       end
 
       describe 'validations' do
+        let(:data) { VALID_REQUEST_DATA.dup }
+
         it 'has no validation errors if data is present' do
+          result = validate(data)
           expect(result).to be_okay
-          expect(fields).not_to be_nil
+          expect(result.item).not_to be_nil
         end
 
         it 'handles null data' do


### PR DESCRIPTION
This is a cleaning PR in preparation for taking information from the payment result and using it in the salesforce classes.

For this now Salesforce needs both the form data and the data from Stripe. This was an opportunity to review the data structs that we were using for tests, which have been bothering me for a while. 

### Changed:
* The tests now consistently use the same request object, which is equal to the one we are sending in the webapp
* The Salesforce classes now receive both the request data and the payment data returned by the payment gateway.
* The donation validator now takes the amount from the payment data and checks that it is an integer (Stripe returns an integer amount in cents)


### Added
* A new DonationData object to wrap the request data and payment data before sending them to the Salesforce classes.
* A stub for the mailer in the payment tests
* A new payment object for the tests

