### PR TITLE
Disable bundler-audit

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,7 @@
 ---
 engines:
   bundler-audit:
-    enabled: true
+    enabled: false
   duplication:
     enabled: true
     config:


### PR DESCRIPTION
This PR updates `.codeclimate.yml` to disable `bundler-audit`

Because `bundler-audit` works by cross-referencing our gems
against [the Ruby Advisory DB](https://github.com/rubysec/ruby-advisory-db), it will error unless there's a
`Gemfile.lock` present in the repo. 

