### PR TITLE
Paypal first step

### DIFF
--- a/donation_system.gemspec
+++ b/donation_system.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'mail', '~> 2.7', '>= 2.7.0'
   spec.add_dependency 'money', '~> 6.10', '>= 6.10.0'
+  spec.add_dependency 'paypal-sdk-rest', '~> 1.7', '>= 1.7.2'
   spec.add_dependency 'restforce', '~> 2.5.3'
   spec.add_dependency 'stripe', '~> 3.8', '>= 3.8.0'
 

--- a/lib/donation_system.rb
+++ b/lib/donation_system.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require 'donation_system/payment'
+require 'donation_system/paypal_wrapper/payment_creator'

--- a/lib/donation_system/paypal_wrapper/creator_data_validator.rb
+++ b/lib/donation_system/paypal_wrapper/creator_data_validator.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'money'
+require 'uri'
+
+module DonationSystem
+  class CreatorDataValidator
+    def self.execute(data)
+      new(data).execute
+    end
+
+    def initialize(data)
+      @data = data
+    end
+
+    def execute
+      validation = Validation.new
+      validation << validate_data
+      validation << validate_amount
+      validation << validate_currency
+      validation << validate_return_url
+      validation << validate_cancel_url
+      validation
+    end
+
+    private
+
+    attr_reader :data
+
+    def validate_data
+      :missing_data unless data
+    end
+
+    def validate_amount
+      :invalid_amount unless data&.amount && number?(data.amount) &&
+                             number(data.amount).positive?
+    end
+
+    def validate_currency
+      :invalid_currency unless data&.currency && currency?
+    end
+
+    def validate_return_url
+      :invalid_return_url unless data&.return_url && valid_url?(data.return_url)
+    end
+
+    def validate_cancel_url
+      :invalid_cancel_url unless data&.cancel_url && valid_url?(data.cancel_url)
+    end
+
+    def number?(string)
+      number(string)
+    rescue ArgumentError
+      false
+    end
+
+    def number(string)
+      BigDecimal(string)
+    end
+
+    def currency?
+      Money::Currency.new(data.currency)
+    rescue Money::Currency::UnknownCurrency
+      false
+    end
+
+    def valid_url?(url)
+      url =~ URI::DEFAULT_PARSER.regexp[:ABS_URI]
+    end
+
+    class Validation
+      attr_reader :errors
+
+      def initialize
+        @errors = []
+      end
+
+      def <<(error)
+        errors << error if error
+      end
+
+      def okay?
+        errors.empty?
+      end
+    end
+  end
+end

--- a/lib/donation_system/paypal_wrapper/creator_fields_generator.rb
+++ b/lib/donation_system/paypal_wrapper/creator_fields_generator.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'money'
+
+require_relative '../result'
+require_relative '../utils'
+
+module DonationSystem
+  module PaypalWrapper
+    class CreatorFieldsGenerator
+      INTENT = 'sale'
+      PAYPAL_METHOD = 'paypal'
+      NUMBER_PREFIX = 'P'
+
+      def self.execute(data)
+        new(data).execute
+      end
+
+      def initialize(data)
+        @data = data
+      end
+
+      def execute
+        {
+          intent: INTENT,
+          payer: { payment_method: PAYPAL_METHOD },
+          redirect_urls: redirect_urls,
+          transactions: [{
+            amount: { total: amount, currency: currency },
+            description: utils.generate_number(NUMBER_PREFIX)
+          }]
+        }
+      end
+
+      private
+
+      attr_reader :data
+
+      def amount
+        I18n.enforce_available_locales = false
+        Money.from_amount(BigDecimal(data.amount).abs, data.currency).to_s
+      end
+
+      def currency
+        data.currency.upcase
+      end
+
+      def redirect_urls
+        {
+          return_url: data.return_url,
+          cancel_url: data.cancel_url
+        }
+      end
+
+      def utils
+        Utils.new
+      end
+    end
+  end
+end

--- a/lib/donation_system/paypal_wrapper/payment_creator.rb
+++ b/lib/donation_system/paypal_wrapper/payment_creator.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'paypal-sdk-rest'
+
+require_relative 'creator_data_validator'
+require_relative 'creator_fields_generator'
+require_relative '../result'
+
+module DonationSystem
+  module PaypalWrapper
+    class PaymentCreator
+      include PayPal::SDK::REST
+
+      def self.execute(data)
+        new(data).execute
+      end
+
+      def initialize(data)
+        @data = data
+        @errors = []
+        config_paypal
+      end
+
+      def execute
+        Result.new(payment, errors)
+      end
+
+      private
+
+      attr_reader :data, :errors
+
+      def payment
+        return failure unless validation.okay?
+        payment = PayPal::SDK::REST::DataTypes::Payment.new(fields)
+        rescue_errors { payment.create }
+        save_error(payment.error) if payment.error
+        payment
+      end
+
+      def rescue_errors
+        yield
+      rescue PayPal::SDK::Core::Exceptions::UnauthorizedAccess
+        errors << :unauthorized_access
+      rescue PayPal::SDK::Core::Exceptions::ServerError
+        errors << :internal_server_error
+      rescue StandardError
+        errors << :unknown_error
+      end
+
+      def save_error(error)
+        errors << error.name.downcase.to_sym
+      end
+
+      def failure
+        @errors += validation.errors
+        nil
+      end
+
+      def validation
+        @validation ||= CreatorDataValidator.execute(data)
+      end
+
+      def fields
+        CreatorFieldsGenerator.execute(data)
+      end
+
+      def config_paypal
+        PayPal::SDK::REST.set_config(
+          mode: ENV['PAYPAL_MODE'],
+          client_id: ENV['PAYPAL_CLIENT_ID'],
+          client_secret: ENV['PAYPAL_CLIENT_SECRET'],
+          ssl_options: {}
+        )
+      end
+    end
+  end
+end

--- a/lib/donation_system/stripe_wrapper/fields_generator.rb
+++ b/lib/donation_system/stripe_wrapper/fields_generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'money'
+require_relative '../utils'
 
 module DonationSystem
   module StripeWrapper
@@ -15,7 +16,7 @@ module DonationSystem
           currency: data.currency,
           source: data.token,
           description: "Charge for #{data.email}",
-          metadata: { number: generate_number('P') }
+          metadata: { number: utils.generate_number('P') }
         }
       end
 
@@ -54,10 +55,6 @@ module DonationSystem
         Money.from_amount(BigDecimal(data.amount).abs, data.currency).cents
       end
 
-      def generate_number(number_prefix)
-        number_prefix + Array.new(9) { Random.rand(9) }.join
-      end
-
       def subscription_metadata(plan, customer)
         card = card_data(customer)
         {
@@ -72,11 +69,15 @@ module DonationSystem
       end
 
       def mandate_number
-        @mandate_number ||= generate_number('MC')
+        @mandate_number ||= utils.generate_number('MC')
       end
 
       def card_data(customer)
         customer.sources.data.first
+      end
+
+      def utils
+        Utils.new
       end
     end
   end

--- a/lib/donation_system/utils.rb
+++ b/lib/donation_system/utils.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DonationSystem
+  class Utils
+    def generate_number(number_prefix)
+      number_prefix + Array.new(9) { Random.rand(9) }.join
+    end
+  end
+end

--- a/spec/donation_system/data_structs_for_tests.rb
+++ b/spec/donation_system/data_structs_for_tests.rb
@@ -83,4 +83,9 @@ module DonationSystem
     SubscriptionMetadataFake.new('4242', 'Visa', '8', '2100', 'MC123456789'),
     1_510_917_211
   )
+
+  PaypalCreatorData = Struct.new(:amount, :currency, :return_url, :cancel_url)
+  VALID_PAYPAL_CREATOR_DATA = PaypalCreatorData.new(
+    '12.345', 'gbp', 'https://your-return-url.com', 'https://your-cancel-url.com'
+  ).freeze
 end

--- a/spec/donation_system/data_structs_for_tests.rb
+++ b/spec/donation_system/data_structs_for_tests.rb
@@ -3,7 +3,8 @@
 module DonationSystem
   RawRequestData = Struct.new(:type, :amount, :currency, :giftaid, :token,
                               :name, :email,
-                              :address, :city, :state, :zip, :country)
+                              :address, :city, :state, :zip, :country,
+                              :method)
   OneOffPaymentData = Struct.new(
     :id, :amount, :currency, :created, :last4, :brand, :method, :record_type_id,
     :number
@@ -44,7 +45,8 @@ module DonationSystem
   VALID_REQUEST_DATA = RawRequestData.new(
     'one-off', '12.345', 'gbp', true, 'tok_visa',
     'Firstname Lastname', 'user@example.com',
-    'Address', 'City', 'State', 'Z1PC0D3', 'Country'
+    'Address', 'City', 'State', 'Z1PC0D3', 'Country',
+    'stripe'
   ).freeze
 
   VALID_ONEOFF_PAYMENT_DATA = OneOffPaymentData.new(

--- a/spec/donation_system/paypal_wrapper/creator_data_validator_spec.rb
+++ b/spec/donation_system/paypal_wrapper/creator_data_validator_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'donation_system/data_structs_for_tests'
+require 'donation_system/paypal_wrapper/creator_data_validator'
+require 'spec_helper'
+
+module DonationSystem
+  RSpec.describe CreatorDataValidator do
+    let(:data) { VALID_PAYPAL_CREATOR_DATA.dup }
+
+    it 'has no validation errors if data is present' do
+      result = validate(data)
+      expect(result).to be_okay
+    end
+
+    it 'handles null data' do
+      result = validate(nil)
+      expect(result.errors).to include(:missing_data)
+    end
+
+    it 'handles missing amount' do
+      data.amount = nil
+      expect_validation_to_fail_with(:invalid_amount)
+    end
+
+    it 'handles invalid amount' do
+      data.amount = 'asdf'
+      expect_validation_to_fail_with(:invalid_amount)
+    end
+
+    it 'handles valid but negative amount' do
+      data.amount = '-12.34567'
+      expect_validation_to_fail_with(:invalid_amount)
+    end
+
+    it 'handles missing currency' do
+      data.currency = nil
+      expect_validation_to_fail_with(:invalid_currency)
+    end
+
+    it 'handles invalid currency' do
+      data.currency = ''
+      expect_validation_to_fail_with(:invalid_currency)
+    end
+
+    it 'handles unsupported currency' do
+      data.currency = 'unsupported'
+      expect_validation_to_fail_with(:invalid_currency)
+    end
+
+    it 'handles missing return url' do
+      data.return_url = nil
+      expect_validation_to_fail_with(:invalid_return_url)
+    end
+
+    it 'handles invalid return url' do
+      data.return_url = ''
+      expect_validation_to_fail_with(:invalid_return_url)
+    end
+
+    it 'handles unsupported return url' do
+      data.return_url = 'unsupported'
+      expect_validation_to_fail_with(:invalid_return_url)
+    end
+
+    it 'handles unsupported cancel url' do
+      data.cancel_url = 'unsupported'
+      expect_validation_to_fail_with(:invalid_cancel_url)
+    end
+
+    def expect_validation_to_fail_with(error)
+      result = validate(data)
+      expect(result.errors).to include(error)
+    end
+
+    def validate(data)
+      described_class.execute(data)
+    end
+  end
+end

--- a/spec/donation_system/paypal_wrapper/creator_fields_generator_spec.rb
+++ b/spec/donation_system/paypal_wrapper/creator_fields_generator_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'donation_system/data_structs_for_tests'
+require 'donation_system/paypal_wrapper/creator_fields_generator'
+require 'spec_helper'
+
+module DonationSystem
+  module PaypalWrapper
+    RSpec.describe CreatorFieldsGenerator do
+      let(:fields) do
+        allow(Random).to receive(:rand).and_return(0)
+        described_class.execute(VALID_PAYPAL_CREATOR_DATA)
+      end
+
+      it 'has required field intent' do
+        expect(fields[:intent]).to eq('sale')
+      end
+
+      it 'has required field payer' do
+        expect(fields[:payer][:payment_method]).to eq('paypal')
+      end
+
+      it 'has required field for paypal method redirect urls' do
+        expect(fields[:redirect_urls][:return_url]).not_to be_nil
+        expect(fields[:redirect_urls][:cancel_url]).not_to be_nil
+      end
+
+      it 'has required field amount' do
+        expect(fields[:transactions].first[:amount]).not_to be_nil
+      end
+
+      it 'has required field total with no more than 2 digits' do
+        expect(fields[:transactions].first[:amount][:total]).to eq('12.34')
+      end
+
+      it 'has required field currency in uppercase' do
+        expect(fields[:transactions].first[:amount][:currency]).to eq('GBP')
+      end
+
+      it 'has optional field description' do
+        expect(fields[:transactions].first[:description]).to eq('P000000000')
+      end
+    end
+  end
+end

--- a/spec/donation_system/paypal_wrapper/payment_creator_spec.rb
+++ b/spec/donation_system/paypal_wrapper/payment_creator_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'donation_system/data_structs_for_tests'
+require 'donation_system/paypal_wrapper/payment_creator'
+require 'support/with_env'
+require 'spec_helper'
+
+module DonationSystem
+  module PaypalWrapper
+    RSpec.describe PaymentCreator do
+      include Support::WithEnv
+
+      let(:result) do
+        described_class.execute(VALID_PAYPAL_CREATOR_DATA)
+      end
+
+      describe 'when successful', vcr: { record: :once } do
+        it 'works' do
+          expect(result).to be_okay
+        end
+
+        it 'returns the payment' do
+          expect(result.item.id).to include('PAY-')
+        end
+      end
+
+      describe 'when unsuccessful', vcr: { record: :once } do
+        let(:paypal_payment) { PayPal::SDK::REST::DataTypes::Payment }
+
+        it 'fails if there are problems with input data validation' do
+          result = described_class.execute(nil)
+          expect(result).not_to be_okay
+        end
+
+        it 'does not work if fields are missing' do
+          allow(paypal_payment).to receive(:new).and_return(paypal_payment.new)
+          expect(result.errors).to include(:validation_error)
+        end
+
+        it 'does not work without a client id' do
+          with_env('PAYPAL_CLIENT_ID' => nil) do
+            expect(result.errors).to include(:unauthorized_access)
+          end
+        end
+
+        it 'fails if there are server errors' do
+          allow_any_instance_of(paypal_payment).to receive(:create)
+            .and_raise(PayPal::SDK::Core::Exceptions::ServerError, 'response')
+          expect(result.errors).to include(:internal_server_error)
+        end
+
+        it 'can fail for other reasons' do
+          allow_any_instance_of(paypal_payment).to receive(:create)
+            .and_raise(StandardError, 'error')
+          expect(result.errors).to include(:unknown_error)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,7 +89,7 @@ RSpec.configure do |config|
 
   # This setting enables warnings. It's recommended, but in some cases may
   # be too noisy due to issues in dependencies.
-  config.warnings = true
+  config.warnings = false
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an


### PR DESCRIPTION
As opposed to Stripe, [PayPal has a previous step](https://developer.paypal.com/docs/integration/direct/express-checkout/integration-jsv4/server-side-REST-integration/) where you have to actually tell your server to create a payment and return the id of the payment to their `checkout.js` library. Once the user authorizes the payment, Paypal calls the `onAuthorize` method in js. From there on we send the form to the server and the apyment goes on like in Stripe.

This PR adds this first step.

### Notes to reviewer

* The credentials repo has been updated with the Paypal env vars. Please update your local copy.
* Travis and Heroku have been updated as well
* After this we have enough cases to refactor the repetition in the validators in a future PR, probably the composite pattern can be applied to select the validations we want in each case.
* The Paypal logger logs a lot of info that we don't necessary need for the tests, this can also be tackled in a future PR
